### PR TITLE
Corrects URI of annotation property 'sex-based context'

### DIFF
--- a/phaleron-app.owl
+++ b/phaleron-app.owl
@@ -66,18 +66,12 @@
     <!-- http://purl.org/dc/elements/1.1/title -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/title"/>
-    
-
-
-    <!-- http://purl.org/sig/ont/fma/definition -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/sig/ont/fma/definition"/>
 
 
 
     <!-- http://w3id.org/rdfbones/anthrograph/app/phaleron-app/sexBasedContext -->
 
-    <owl:AnnotationProperty rdf:about="http://purl.org/sig/ont/fma/definition">
+    <owl:AnnotationProperty rdf:about="http://w3id.org/rdfbones/anthrograph/app/phaleron-app/sexBasedContext">
         <obo:IAO_0000115 xml:lang="en">Indicates the sex-based role of a specimen in the context of which a class is to be used.</obo:IAO_0000115>
         <obo:IAO_0000119>https://orcid.org/0009-0008-3871-9762, ""Felix Engel""</obo:IAO_0000119>
         <rdfs:label xml:lang="en">sex-based context</rdfs:label>


### PR DESCRIPTION
This corrects the URI of annotation property 'sex-based context', previously http://purl.org/sig/ont/fma/definition, to the correct URI http://w3id.org/rdfbones/anthrograph/app/phaleron-app/sexBasedContext.

Also removes the class definition for the unwanted http://purl.org/sig/ont/fma/definition.

Fixes #47.